### PR TITLE
Update magixTx_chain_config.js

### DIFF
--- a/src/config/magixTx_chain_config.js
+++ b/src/config/magixTx_chain_config.js
@@ -4,7 +4,7 @@ export const chainNetworks = {
         chainName: "Agoric",
         rpc: "https://airdrop.zenscape.one/agoric-rpc",
         rest: "https://airdrop.zenscape.one/agoric-api",
-        explorerUrlToTx: "https://bigdipper.live/agoric/transactions/{txHash}",
+        explorerUrlToTx: "https://agoric.explorers.guru/transaction/{txHash}",
         coinDenom: "BLD",
         coinMinimalDenom: "ubld",
         coinDecimals: 6,


### PR DESCRIPTION
Updated Agoric explorer URL to 'https://agoric.explorers.guru/transaction/ following Big Dipper's drop of support, referenced Agoric's tweet: https://twitter.com/bigdipperlive/status/1766162059690119486.